### PR TITLE
Adds latest adb files. Installer now opens WSASettings and Installs Magisk.apk with minimal input from user.

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -359,6 +359,7 @@ jobs:
           wget https://dl.google.com/android/repository/platform-tools-latest-windows.zip -Oadb.zip
           unzip adb.zip platform-tools/?db*
           cp platform-tools/?db* ${{ matrix.arch }}/.
+          rm -r platform-tools
       - name: Remove signature and add scripts
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -364,7 +364,6 @@ jobs:
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata
           tee ${{ matrix.arch }}/Install.ps1 <<EOF
-          tee ./Install.ps1 <<EOF
           function Test-Administrator
           {
               [OutputType([bool])]

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -409,9 +409,9 @@ jobs:
               start-process "\$env:LOCALAPPDATA/Microsoft/WindowsApps/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/WsaClient.exe" -Args "/launch wsa://com.amazon.venezia"
               Write-Output "Waiting for the Android system to boot for the first time..."
               adb kill-server
-              do{}until((adb connect localhost:58526).Contains("connected"))
+              do{}until((./adb connect localhost:58526).Contains("connected"))
               do{
-                  \$output=(adb devices)
+                  \$output=(./adb devices)
                   foreach(\$line in \$output){
                       if(\$line.Contains("localhost")){
                           \$connection=\$line

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -342,6 +342,7 @@ jobs:
           resize2fs -M ${{ matrix.arch }}/system_ext.img
       - name: Remove signature and add scripts
         run: |
+          cp magisk.zip ${{ matrix.arch }}/Magisk.apk
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata
           tee ${{ matrix.arch }}/Install.ps1 <<EOF
           function Test-Administrator

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -1,5 +1,4 @@
 name: Magisk
-
 on:
   push:
   pull_request:
@@ -388,8 +387,8 @@ jobs:
               Write-Host "2. In WSA Settings App, Open 'Manage developer settings'. Wait for the new options menu to open."
               Read-Host  "***Press ENTER only when you see the menu options to continue with the installation."
               Write-Host "Installing Magisk App..."
-              ./platform-tools/adb connect localhost:58526
-              ./platform-tools/adb install Magisk.apk
+              ./adb connect localhost:58526
+              ./adb install Magisk.apk
               Start-Sleep -s 5
               \$wsapath = \$env:LOCALAPPDATA + "\Microsoft\WindowsApps\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe"
               cmd /c \$wsapath\WsaClient.exe /launch wsa://com.topjohnwu.magisk

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -357,9 +357,9 @@ jobs:
           resize2fs -M ${{ matrix.arch }}/system_ext.img
       - name: add ADB
         run: |
-        wget https://dl.google.com/android/repository/platform-tools-latest-windows.zip -Oadb.zip
-        unzip adb.zip
-        cp platform-tools/?db* ${{ matrix.arch }}/.
+          wget https://dl.google.com/android/repository/platform-tools-latest-windows.zip -Oadb.zip
+          unzip adb.zip
+          cp platform-tools/?db* ${{ matrix.arch }}/.
       - name: Remove signature and add scripts
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -5,17 +5,17 @@ on:
   workflow_dispatch:
     inputs:
       magisk_apk:
-        description: 'Download link to magisk apk.'
+        description: "Download link to magisk apk."
         required: true
-        default: 'https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/app-debug.apk'
+        default: "https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/app-debug.apk"
       gapps_variant:
-        description: 'Variants of gapps. Should be: [none, aroma, super, stock, full, mini, micro, nano, pico, tvstock, tvmini]'
+        description: "Variants of gapps. Should be: [none, aroma, super, stock, full, mini, micro, nano, pico, tvstock, tvmini]"
         required: true
-        default: 'none'
+        default: "none"
       root_sol:
-        description: 'Root soluction. Should be: [magisk, none]'
+        description: "Root soluction. Should be: [magisk, none]"
         required: true
-        default: 'magisk'
+        default: "magisk"
 
 jobs:
   build:
@@ -384,15 +384,14 @@ jobs:
           Add-AppxPackage -Register .\AppxManifest.xml
           Start-Process shell:appsFolder\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!SettingsApp
           if (Test-Path "./Magisk.apk") {
-              Read-Host  "1. In WSA Settings App, activate DEVELOPER MODE. Press ENTER when done..."
-              Write-Host "2. In WSA Settings App, Open 'Manage developer settings'. Wait for the new options menu to open."
-              Read-Host  "***Press ENTER only when you see the menu options to continue with the installation."
+              Write-Host "1. In WSA Settings App, activate DEVELOPER MODE."
+              Write-Host "2. In WSA Settings App, Open 'Manage developer settings'." 
+              Write-Host "3. Wait for the new options menu to open."
               Write-Host "Installing Magisk App..."
-              ./adb connect localhost:58526
+              ./adb kill-server
+              while (!(./adb connect localhost:58526).Contains("connected")){}
               ./adb install Magisk.apk
-              Start-Sleep -s 5
-              \$wsapath = \$env:LOCALAPPDATA + "\Microsoft\WindowsApps\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe"
-              cmd /c \$wsapath\WsaClient.exe /launch wsa://com.topjohnwu.magisk
+              adb shell monkey -p com.topjohnwu.magisk -v 500
           }
           EOF
       - name: Generate artifact name
@@ -416,4 +415,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.artifact_name }}
-          path: './${{ matrix.arch }}/*'
+          path: "./${{ matrix.arch }}/*"

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -365,6 +365,8 @@ jobs:
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata
           tee ${{ matrix.arch }}/Install.ps1 <<EOF
+          # Automated Install script by Mioki
+          # http://github.com/okibcn
           function Test-Administrator
           {
               [OutputType([bool])]
@@ -380,19 +382,48 @@ jobs:
               Start-Process -Verb RunAs powershell.exe -Args "-executionpolicy bypass -command Set-Location \`"\$PSScriptRoot\`"; \`"\$PSCommandPath\`""
               exit
           }
-
           \$ErrorActionPreference = "Stop";
           Add-AppxPackage -Register .\AppxManifest.xml
-          Start-Process shell:appsFolder\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!SettingsApp
           if (Test-Path "./Magisk.apk") {
-              Write-Host "1. In WSA Settings App, activate DEVELOPER MODE."
-              Write-Host "2. In WSA Settings App, Open 'Manage developer settings'." 
-              Write-Host "3. Wait for the new options menu to open."
-              Write-Host "Installing Magisk App..."
-              ./adb kill-server
-              while (!(./adb connect localhost:58526).Contains("connected")){}
+              do{start-sleep -s 0.5}until((get-process).Name -contains "wsaclient")
+              Stop-Process -Name WsaClient
+              \$regHive = "\$env:LOCALAPPDATA/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/Settings/settings.dat"
+              \$regMountPoint = "HKLM\WSA"
+              Write-Output "Mounting WSA registry hive"
+              reg load \$regMountPoint \$regHive
+              \$develbit = "1"
+              \$reg  = "Windows Registry Editor Version 5.00\`n\`n"
+              \$reg += "[HKEY_LOCAL_MACHINE\WSA]\`n\`n"
+              \$reg += "[HKEY_LOCAL_MACHINE\WSA\LocalState]\`n"
+              \$reg += "\`"DeveloperModeEnabled\`"=hex(5f5e10b):0"+ \$develbit + ",07,b9,6f,f3,d3,dc,d7,01\`n"
+              \$reg += "\`"OptionalDiagnosticDataEnabled\`"=hex(5f5e10b):00,dc,38,ba,75,ec,dc,d7,01\`n"
+              \$reg | Out-File "./wsa.reg"
+              Write-Output "Patching WSA registry..."
+              reg import "./wsa.reg"
+              rm -force wsa*.reg
+              [gc]::collect()
+              start-sleep -s 3
+              Write-Output "Unmounting patched WSA registry hive."
+              reg unload \$regMountPoint
+              Write-Output "starting an App to force the creation of the rw sdcard"
+              start-process "\$env:LOCALAPPDATA/Microsoft/WindowsApps/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/WsaClient.exe" -Args "/launch wsa://com.amazon.venezia"
+              Write-Output "Waiting for the Android system to boot for the first time..."
+              adb kill-server
+              do{}until((adb connect localhost:58526).Contains("connected"))
+              do{
+                  \$output=(adb devices)
+                  foreach(\$line in \$output){
+                      if(\$line.Contains("localhost")){
+                          \$connection=\$line
+                      }
+                  }
+              }until(\$connection.Contains("device"))
+              Write-Output "WSA loaded and Developer mode is ON."
+              do{start-sleep -s 0.5}until(./adb shell "ps -d | grep 'com.amazon.venezia'")
+              ./adb shell am force-stop com.amazon.venezia
+              Write-Output "Installing Magisk App..."
               ./adb install Magisk.apk
-              ./adb shell monkey -p com.topjohnwu.magisk -c android.intent.category.LAUNCHER 1
+              adb shell monkey -p com.topjohnwu.magisk -c android.intent.category.LAUNCHER 1
           }
           EOF
       - name: Generate artifact name

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -360,6 +360,7 @@ jobs:
           unzip adb.zip platform-tools/?db*
           cp platform-tools/?db* ${{ matrix.arch }}/.
           rm -r platform-tools
+          rm adb.zip
       - name: Remove signature and add scripts
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Integrate Magisk
         if: ${{ github.event.inputs.root_sol == 'magisk' || github.event.inputs.root_sol == '' }}
         run: |
+          cp magisk.zip ${{ matrix.arch }}/Magisk.apk
           sudo mkdir system/sbin
           sudo chcon --reference system/init.environ.rc system/sbin
           sudo chown root:root system/sbin
@@ -342,7 +343,6 @@ jobs:
           resize2fs -M ${{ matrix.arch }}/system_ext.img
       - name: Remove signature and add scripts
         run: |
-          cp magisk.zip ${{ matrix.arch }}/Magisk.apk
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata
           tee ${{ matrix.arch }}/Install.ps1 <<EOF
           function Test-Administrator

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -382,7 +382,8 @@ jobs:
               Start-Process -Verb RunAs powershell.exe -Args "-executionpolicy bypass -command Set-Location \`"\$PSScriptRoot\`"; \`"\$PSCommandPath\`""
               exit
           }
-          \$ErrorActionPreference = "Stop";
+          \$ErrorActionPreference = "Stop"
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWO RD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
           Add-AppxPackage -Register .\AppxManifest.xml
           if (Test-Path "./Magisk.apk") {
               Write-Output "Magisk detected, installing..."

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -355,10 +355,16 @@ jobs:
           resize2fs -M ${{ matrix.arch }}/product.img
           e2fsck -yf ${{ matrix.arch }}/system_ext.img
           resize2fs -M ${{ matrix.arch }}/system_ext.img
+      - name: add ADB
+        run: |
+        wget https://dl.google.com/android/repository/platform-tools-latest-windows.zip -Oadb.zip
+        unzip adb.zip
+        cp platform-tools/?db* ${{ matrix.arch }}/.
       - name: Remove signature and add scripts
         run: |
           rm -rf ${{ matrix.arch }}/\[Content_Types\].xml ${{ matrix.arch }}/AppxBlockMap.xml ${{ matrix.arch }}/AppxSignature.p7x ${{ matrix.arch }}/AppxMetadata
           tee ${{ matrix.arch }}/Install.ps1 <<EOF
+          tee ./Install.ps1 <<EOF
           function Test-Administrator
           {
               [OutputType([bool])]
@@ -377,6 +383,18 @@ jobs:
 
           \$ErrorActionPreference = "Stop";
           Add-AppxPackage -Register .\AppxManifest.xml
+          Start-Process shell:appsFolder\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe!SettingsApp
+          if (Test-Path "./Magisk.apk") {
+              Read-Host  "1. In WSA Settings App, activate DEVELOPER MODE. Press ENTER when done..."
+              Write-Host "2. In WSA Settings App, Open 'Manage developer settings'. Wait for the new options menu to open."
+              Read-Host  "***Press ENTER only when you see the menu options to continue with the installation."
+              Write-Host "Installing Magisk App..."
+              ./platform-tools/adb connect localhost:58526
+              ./platform-tools/adb install Magisk.apk
+              Start-Sleep -s 5
+              \$wsapath = \$env:LOCALAPPDATA + "\Microsoft\WindowsApps\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe"
+              cmd /c \$wsapath\WsaClient.exe /launch wsa://com.topjohnwu.magisk
+          }
           EOF
       - name: Generate artifact name
         run: |

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -385,8 +385,15 @@ jobs:
           \$ErrorActionPreference = "Stop";
           Add-AppxPackage -Register .\AppxManifest.xml
           if (Test-Path "./Magisk.apk") {
-              do{start-sleep -s 0.5}until((get-process).Name -contains "wsaclient")
-              Stop-Process -Name WsaClient
+              Write-Output "Magisk detected, installing..."
+              \$i = 20
+              do{
+                  start-sleep -s 0.5
+                  \$i--
+              }until( (\$i -eq 0) -or ((get-process).Name -contains "wsaclient") )
+              if ((get-process).Name -contains "wsaclient") {
+                  Stop-Process -Name WsaClient
+              }
               \$regHive = "\$env:LOCALAPPDATA/Packages/MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe/Settings/settings.dat"
               \$regMountPoint = "HKLM\WSA"
               Write-Output "Mounting WSA registry hive"

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -391,7 +391,7 @@ jobs:
               ./adb kill-server
               while (!(./adb connect localhost:58526).Contains("connected")){}
               ./adb install Magisk.apk
-              adb shell monkey -p com.topjohnwu.magisk -c android.intent.category.LAUNCHER 1
+              ./adb shell monkey -p com.topjohnwu.magisk -c android.intent.category.LAUNCHER 1
           }
           EOF
       - name: Generate artifact name

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -383,7 +383,7 @@ jobs:
               exit
           }
           \$ErrorActionPreference = "Stop"
-          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWO RD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
+          reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d "1"
           Add-AppxPackage -Register .\AppxManifest.xml
           if (Test-Path "./Magisk.apk") {
               Write-Output "Magisk detected, installing..."

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -391,7 +391,7 @@ jobs:
               ./adb kill-server
               while (!(./adb connect localhost:58526).Contains("connected")){}
               ./adb install Magisk.apk
-              adb shell monkey -p com.topjohnwu.magisk -v 500
+              adb shell monkey -p com.topjohnwu.magisk -c android.intent.category.LAUNCHER 1
           }
           EOF
       - name: Generate artifact name

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -357,7 +357,7 @@ jobs:
       - name: add ADB
         run: |
           wget https://dl.google.com/android/repository/platform-tools-latest-windows.zip -Oadb.zip
-          unzip adb.zip
+          unzip adb.zip platform-tools/?db*
           cp platform-tools/?db* ${{ matrix.arch }}/.
       - name: Remove signature and add scripts
         run: |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     ![Workflow](https://docs.github.com/assets/images/actions-select-workflow.png)
 1. Above the list of workflow runs, select **Run workflow**
     ![Run Workflow](https://docs.github.com/assets/images/actions-workflow-dispatch.png)
-1. Input the download link of Magisk and select the [OpenGApps variant](https://github.com/opengapps/opengapps/wiki#variants) (none is no OpenGApps) you like and click **Run workflow**
+1. Input the download link of Magisk and select the [OpenGApps variant](https://github.com/opengapps/opengapps/wiki#variants) (none is no OpenGApps) you like, select the root solution (none means no root) and click **Run workflow**
     ![Run Workflow](https://docs.github.com/assets/images/actions-manually-run-workflow.png)
 1. Wait for the action to complete and download the artifact
     ![Download](https://docs.github.com/assets/images/help/repository/artifact-drop-down-updated.png)
@@ -25,9 +25,8 @@
 1. Enable developer mode on Windows
 1. Right-click `Install.ps1` and select `Run with PowerShell`
 1. Launch WSA and enable developer mode, launch the file manager, and wait until the file manager popup
-1. Make sure you have [Platform tools](https://developer.android.com/studio/releases/platform-tools), run `adb connect localhost:58526` to connect to WSA, `adb install magisk.apk` to install Magisk App (the one you used to build) and launch it
-1. Fix the environment as the Magisk app will prompt and reboot (sometimes it keeps prompting even after environment fix, just ignore it)
-1. Enjoy by installing Riru and LSPosed
+1. If you use Magisk as root solution, make sure you have [Platform tools](https://developer.android.com/studio/releases/platform-tools), run `adb connect localhost:58526` to connect to WSA, `adb install magisk.apk` to install Magisk App (the one you used to build, included in the zip artifacts as `Magisk.apk`), launch it and fix the environment as the Magisk app will prompt and reboot (sometimes it keeps prompting even after environment fix, just ignore it)
+1. Enjoy by installing LSPosed-zygisk with zygisk enabled or Riru and LSPosed-riru
 
 ## Video Demo
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 - Support both ARM64 and x64
 - Support all OpenGApps variants
 - Fix external storage access of DocumentUI
+- Unatended installation
+- Automatically activates developers mode in Windows 11
+- Automatically activates developer mode in WSA
 
 ## Usage
 
@@ -22,7 +25,6 @@
 1. Wait for the action to complete and download the artifact
     ![Download](https://docs.github.com/assets/images/help/repository/artifact-drop-down-updated.png)
 1. Unzip the artifact and uninstall WSA if you have an official installation or replace the previously unzipped artifact if you have a manual installation
-1. Enable developer mode on Windows
 1. Right-click `Install.ps1` and select `Run with PowerShell`
 1. Enjoy by installing LSPosed-zygisk with zygisk enabled or Riru and LSPosed-riru
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 1. Unzip the artifact and uninstall WSA if you have an official installation or replace the previously unzipped artifact if you have a manual installation
 1. Enable developer mode on Windows
 1. Right-click `Install.ps1` and select `Run with PowerShell`
-1. Launch WSA and enable developer mode, launch the file manager, and wait until the file manager popup
-1. If you use Magisk as root solution, make sure you have [Platform tools](https://developer.android.com/studio/releases/platform-tools), run `adb connect localhost:58526` to connect to WSA, `adb install magisk.apk` to install Magisk App (the one you used to build, included in the zip artifacts as `Magisk.apk`), launch it and fix the environment as the Magisk app will prompt and reboot (sometimes it keeps prompting even after environment fix, just ignore it)
 1. Enjoy by installing LSPosed-zygisk with zygisk enabled or Riru and LSPosed-riru
 
 ## Video Demo


### PR DESCRIPTION
In order to complete a silent installation:
- The Workflow now downloads and adds the ADB files from the latest Android Platform Tools
- The Install script automatically activates Windows 11 developers mode.
- If Magisk is selected, the PowerShell installation script now
      a) Configures Developer mode in WSA
      b) Boots Android
      c) Sideloads Magisk.apk
      d) Opens Magisk App to complete Magisk installation.

TODO: If Magisk is not selected, start Google Play Store if installed, otherwise start Amazon Play store.