### PR TITLE
Simplified the selection of the Magisk release

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -116,10 +116,7 @@ jobs:
           if not magisk_apk:
               magisk_apk = "stable"
           if magisk_apk == "stable" or magisk_apk == "beta" or magisk_apk == "canary":
-              magisk_file = urllib.request.urlopen(f"https://raw.githubusercontent.com/topjohnwu/magisk-files/master/{magisk_apk}.json")
-              magisk_file_read = magisk_file.read()
-              magisk_file_json = json.loads(magisk_file_read)
-              magisk_apk = magisk_file_json['magisk']['link']
+              magisk_apk = json.loads(requests.get(f"https://github.com/topjohnwu/magisk-files/raw/master/{magisk_apk}.json").content)['magisk']['link']
 
           out_file = "magisk.zip"
 

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -107,6 +107,7 @@ jobs:
         shell: python
         run: |
           import urllib.request
+          import requests
           import zipfile
           import os
           import json

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -110,6 +110,7 @@ jobs:
           import zipfile
           import os
           import json
+          import requests
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
 

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -110,14 +110,13 @@ jobs:
           import zipfile
           import os
           import json
-          from urllib.request import urlopen
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
-                    
+
           if not magisk_apk:
               magisk_apk = "stable"
           if magisk_apk == "stable" or magisk_apk == "beta" or magisk_apk == "canary":
-              magisk_file = urlopen(f"https://raw.githubusercontent.com/topjohnwu/magisk-files/master/{magisk_apk}.json")
+              magisk_file = urllib.request.urlopen(f"https://raw.githubusercontent.com/topjohnwu/magisk-files/master/{magisk_apk}.json")
               magisk_file_read = magisk_file.read()
               magisk_file_json = json.loads(magisk_file_read)
               magisk_apk = magisk_file_json['magisk']['link']

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -107,10 +107,10 @@ jobs:
         shell: python
         run: |
           import urllib.request
-          import requests
           import zipfile
           import os
           import json
+          from urllib.request import urlopen
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
                     

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       magisk_apk:
-        description: "Download magisk apk. Should be: [stable, canary]"
+        description: "Magisk version. Should be stable, canary or a download link to Magisk apk."
         required: true
         default: "stable"
       gapps_variant:

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       magisk_apk:
-        description: "Download link to magisk apk."
+        description: "Download magisk apk. Should be: [stable, canary]"
         required: true
-        default: "https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@24.1/app-release.apk"
+        default: "stable"
       gapps_variant:
         description: "Variants of gapps. Should be: [none, super, stock, full, mini, micro, nano, pico, tvstock, tvmini]"
         required: true
@@ -112,8 +112,10 @@ jobs:
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
 
-          if not magisk_apk:
-              magisk_apk = """https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@24.1/app-release.apk"""
+          if not magisk_apk or magisk_apk == "stable":
+              magisk_apk = """https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@24.1/app-release.apk"""              
+          elif magisk_apk == "canary":
+              magisk_apk = """https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/app-debug.apk"""
 
           out_file = "magisk.zip"
 

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -114,20 +114,10 @@ jobs:
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
                     
-          if not magisk_apk or magisk_apk == "stable":
-              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/stable.json")
-              magisk_file_read = magisk_file.read()
-              magisk_file_json = json.loads(magisk_file_read)
-              magisk_apk = magisk_file_json['magisk']['link']
-              
-          elif magisk_apk == "beta":
-              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/beta.json")
-              magisk_file_read = magisk_file.read()
-              magisk_file_json = json.loads(magisk_file_read)
-              magisk_apk = magisk_file_json['magisk']['link']
-              
-          elif magisk_apk == "canary":
-              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/canary.json")
+          if not magisk_apk:
+              magisk_apk = "stable"
+          if magisk_apk == "stable" or magisk_apk == "beta" or magisk_apk == "canary":
+              magisk_file = urlopen(f"https://raw.githubusercontent.com/topjohnwu/magisk-files/master/{magisk_apk}.json")
               magisk_file_read = magisk_file.read()
               magisk_file_json = json.loads(magisk_file_read)
               magisk_apk = magisk_file_json['magisk']['link']

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       magisk_apk:
-        description: "Magisk version. Should be stable, canary or a download link to Magisk apk."
+        description: "Magisk version. Should be stable, beta, canary or a download link to Magisk apk."
         required: true
         default: "stable"
       gapps_variant:
@@ -107,21 +107,29 @@ jobs:
         shell: python
         run: |
           import urllib.request
-          import requests
           import zipfile
           import os
+          import json
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
-          
-          GetLatestlink = requests.get('https://github.com/topjohnwu/Magisk/releases/latest') 
-          Latestlink = GetLatestlink.url
-          ii = Latestlink.rfind('/v')
-          Latestv = Latestlink[ii+2:]
-
+                    
           if not magisk_apk or magisk_apk == "stable":
-              magisk_apk = """https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@""" + Latestv + """/app-release.apk"""              
+              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/stable.json")
+              magisk_file_read = magisk_file.read()
+              magisk_file_json = json.loads(magisk_file_read)
+              magisk_apk = magisk_file_json['magisk']['link']
+              
+          elif magisk_apk == "beta":
+              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/canary.json")
+              magisk_file_read = magisk_file.read()
+              magisk_file_json = json.loads(magisk_file_read)
+              magisk_apk = magisk_file_json['magisk']['link']
+              
           elif magisk_apk == "canary":
-              magisk_apk = """https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/app-debug.apk"""
+              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/beta.json")
+              magisk_file_read = magisk_file.read()
+              magisk_file_json = json.loads(magisk_file_read)
+              magisk_apk = magisk_file_json['magisk']['link']
 
           out_file = "magisk.zip"
 

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -107,13 +107,19 @@ jobs:
         shell: python
         run: |
           import urllib.request
+          import requests
           import zipfile
           import os
 
           magisk_apk = """${{ github.event.inputs.magisk_apk }}"""
+          
+          GetLatestlink = requests.get('https://github.com/topjohnwu/Magisk/releases/latest') 
+          Latestlink = GetLatestlink.url
+          ii = Latestlink.rfind('/v')
+          Latestv = Latestlink[ii+2:]
 
           if not magisk_apk or magisk_apk == "stable":
-              magisk_apk = """https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@24.1/app-release.apk"""              
+              magisk_apk = """https://cdn.jsdelivr.net/gh/topjohnwu/magisk-files@""" + Latestv + """/app-release.apk"""              
           elif magisk_apk == "canary":
               magisk_apk = """https://raw.githubusercontent.com/topjohnwu/magisk-files/canary/app-debug.apk"""
 

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -121,13 +121,13 @@ jobs:
               magisk_apk = magisk_file_json['magisk']['link']
               
           elif magisk_apk == "beta":
-              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/canary.json")
+              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/beta.json")
               magisk_file_read = magisk_file.read()
               magisk_file_json = json.loads(magisk_file_read)
               magisk_apk = magisk_file_json['magisk']['link']
               
           elif magisk_apk == "canary":
-              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/beta.json")
+              magisk_file = urlopen("https://raw.githubusercontent.com/topjohnwu/magisk-files/master/canary.json")
               magisk_file_read = magisk_file.read()
               magisk_file_json = json.loads(magisk_file_read)
               magisk_apk = magisk_file_json['magisk']['link']


### PR DESCRIPTION
In the Magisk field of the workflow window, you can type "stable" (default) or "canary" to download the desired release, instead of the direct download link.  
You can alternatively put a direct download link instead of "stable" or "canary".