### PR TITLE
compress and uplode as release

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -636,5 +636,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GIT }}
         with:
           file: "./${{ env.artifact_name }}.zip"
-          tags: true
+          tags: false
           draft: true

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -629,12 +629,12 @@ jobs:
       - name: Compress
         uses: TonyBogdanov/zip@1.0
         with:
-          args: zip -qq -r ./wsarelease.zip "./${{ matrix.arch }}/*"
+          args: zip -qq -r f"./${{ env.artifact_name }}.zip" "./${{ matrix.arch }}/*"
       - name: to release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GIT }}
         with:
-          file: "./wsarelease.zip"
+          file: f"./${{ env.artifact_name }}.zip"
           tags: true
           draft: true

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -629,7 +629,7 @@ jobs:
       - name: to release
         uses: xresloader/upload-to-github-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GIT }}
         with:
           file: "*.md"
           tags: true

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -20,7 +20,7 @@ on:
       release_type:
         description: "WSA release type"
         required: true
-        default: "retail"
+        default: "insider fast"
         type: choice
         options:
         - retail
@@ -30,7 +30,7 @@ on:
       magisk_apk:
         description: "Magisk version"
         required: true
-        default: "stable"
+        default: "beta"
         type: choice
         options:
         - stable
@@ -39,7 +39,7 @@ on:
       gapps_variant:
         description: "Variants of gapps"
         required: true
-        default: "none"
+        default: "pico"
         type: choice
         options:
         - none
@@ -63,7 +63,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ahmed] 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -629,7 +629,7 @@ jobs:
       - name: Compress
         uses: TonyBogdanov/zip@1.0
         with:
-          args: zip -qq -r "./${{ env.artifact_name }}.zip" "./${{ matrix.arch }}/*"
+          args: zip -qq -r "./${{ env.artifact_name }}.zip" "./${{ matrix.arch }}/"
       - name: to release
         uses: xresloader/upload-to-github-release@v1
         env:

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -629,12 +629,12 @@ jobs:
       - name: Compress
         uses: TonyBogdanov/zip@1.0
         with:
-          args: zip -qq -r f"./${{ env.artifact_name }}.zip" "./${{ matrix.arch }}/*"
+          args: zip -qq -r "./${{ env.artifact_name }}.zip" "./${{ matrix.arch }}/*"
       - name: to release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GIT }}
         with:
-          file: f"./${{ env.artifact_name }}.zip"
+          file: "./${{ env.artifact_name }}.zip"
           tags: true
           draft: true

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -626,15 +626,15 @@ jobs:
         with:
           name: ${{ env.artifact_name }}
           path: "./${{ matrix.arch }}/*"
+      - name: Compress
+        uses: TonyBogdanov/zip@1.0
+        with:
+          args: zip -qq -r ./wsarelease.zip "./${{ matrix.arch }}/*"
       - name: to release
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GIT }}
         with:
-          file: "*.md"
+          file: "./wsarelease.zip"
           tags: true
           draft: true
-      - name: Compress
-        uses: TonyBogdanov/zip@1.0
-        with:
-          args: zip -qq -r ./wsarelease.zip "./${{ matrix.arch }}/"

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -638,3 +638,4 @@ jobs:
           file: "./${{ env.artifact_name }}.zip"
           tags: false
           draft: true
+          update_latest_release: true

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -63,7 +63,7 @@ on:
 
 jobs:
   matrix:
-    runs-on: [self-hosted, ahmed] 
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -626,3 +626,15 @@ jobs:
         with:
           name: ${{ env.artifact_name }}
           path: "./${{ matrix.arch }}/*"
+      - name: to release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: "*.md"
+          tags: true
+          draft: true
+      - name: Compress
+        uses: TonyBogdanov/zip@1.0
+        with:
+          args: zip -qq -r ./wsarelease.zip "./${{ matrix.arch }}/"


### PR DESCRIPTION
compressing wsa package into small size (WSA-with-magisk-GApps-pico_2203.40000.3.0_x64_Release-Nightly) only 817 MB
then uploding this file to a new release

for me releases is better as downloading artifacts not supporting resumable downloading and it's impossible to download the file at my net speed, 
but releases supports this
I appreciate your hard work, and hope if you can make an offline version to build offline
Thank you.