### PR TITLE
Simplify Magisk version chooser

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -19,20 +19,21 @@ on:
         options:
         - retail
         - release preview
-        - insider slow
-        - insider fast
+        - beta
+        - dev
       magisk_apk:
         description: "Magisk version"
         required: true
         default: "stable"
         type: choice
         options:
+        - none
         - stable
         - beta
         - canary
         - debug
       gapps_variant:
-        description: "Variants of gapps"
+        description: "Open GApps variant"
         required: true
         default: "none"
         type: choice
@@ -47,14 +48,6 @@ on:
         - pico
         - tvstock
         - tvmini
-      root_sol:
-        description: "Root solution"
-        required: true
-        default: "magisk"
-        type: choice
-        options:
-        - magisk
-        - none
 
 jobs:
   matrix:
@@ -106,7 +99,7 @@ jobs:
           import urllib.request
 
           arch = "${{ matrix.arch }}"
-          release_type_map = {"retail": "Retail", "release preview": "RP", "insider slow": "WIS", "insider fast": "WIF"}
+          release_type_map = {"retail": "Retail", "release preview": "RP", "beta": "WIS", "dev": "WIF"}
           release_type = release_type_map["${{ github.event.inputs.release_type }}"] if "${{ github.event.inputs.release_type }}" != "" else "Retail"
 
           res = requests.post("https://store.rg-adguard.net/api/GetFiles", f"type=CategoryId&url=858014f3-3934-4abe-8078-4aa193e74ca8&ring={release_type}&lang=en-US", headers={
@@ -292,7 +285,7 @@ jobs:
           sudo mount -o loop ${{ matrix.arch }}/product.img system/product
           sudo mount -o loop ${{ matrix.arch }}/system_ext.img system/system_ext
       - name: Integrate Magisk
-        if: ${{ github.event.inputs.root_sol == 'magisk' || github.event.inputs.root_sol == '' }}
+        if: ${{ github.event.inputs.magisk_apk != 'none' }}
         run: |
           sudo mkdir system/sbin
           sudo chcon --reference system/init.environ.rc system/sbin
@@ -620,13 +613,11 @@ jobs:
       - name: Generate artifact name
         run: |
           variant="${{ github.event.inputs.gapps_variant }}"
-          root="${{ github.event.inputs.root_sol }}"
+          root="${{ github.event.inputs.magisk_apk }}"
           if [[ "$root" = "none" ]]; then
             name1=""
-          elif [[ "$root" = "" ]]; then
-            name1="-with-magisk"
           else
-            name1="-with-${root}"
+            name1="-with-magisk"
           fi
           if [[ "$variant" = "none" || "$variant" = "" ]]; then
             name2="-NoGApps"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ https://user-images.githubusercontent.com/5022927/145696886-e13ebfc1-ff25-4410-8
     No. Magisk has bugs preventing itself running on WSA. Magisk 24+ has fixed them. So you must use Magisk 24 or higher version.
 - How can I get rid of Magisk?
 
-    Choose `none` as root solution.
+    Choose `none` as Magisk version.
 - Github Action script is updated, how can I synchronize it?
 
     1. In your fork repository, click `fetch upstream`


### PR DESCRIPTION
And rename Fast/Slow to Dev/Beta.

1. The Magisk version chooser is now coordinated with the Open GApps variant chooser (i.e. choose `none` to disable installation)
2. I think it's very unlikely that another root solution gets added, other than Magisk.
3. `Fast` is now named `Dev`, and `Slow` is now named `Beta` in Windows Insiders. Also, I dropped the `insider` prefix, since `release preview` would also need to be named `insider` in this case.

@yujincheng08 what do you think?