### PR TITLE
update hosts ip 

### DIFF
--- a/.github/workflows/magisk.yml
+++ b/.github/workflows/magisk.yml
@@ -102,7 +102,7 @@ jobs:
           sudo apt-get update && sudo apt-get install setools lzip wine winetricks patchelf
           wget -qO- "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/archive/$GITHUB_REF.tar.gz" | sudo tar --wildcards -zxvf- -C ~ --strip-component=2 '*/wine/*' '*/linker/*'
           winetricks msxml6
-          echo "163.172.251.201 store.rg-adguard.net" | sudo tee -a /etc/hosts
+          echo "172.67.174.18 store.rg-adguard.net" | sudo tee -a /etc/hosts
       - name: Download WSA
         shell: python
         run: |


### PR DESCRIPTION
rg-adguard's IP changed, causing the workflow to fail downloading files from MS because it is unable to resolve. fixes #479 